### PR TITLE
make webhook update fields pointers & omitempty

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -101,10 +101,11 @@ type WebhookResponse struct {
 }
 
 type UpdateWebhookOptions struct {
-	Active      bool     `json:"active"`
-	Description string   `json:"description"`
-	Events      []string `json:"events"`
-	Filter      Filter   `json:"filter"`
+	// pointer fields here are used to allow us to omit certain fields when updating
+	Active      *bool    `json:"active,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Events      []string `json:"events,omitempty"`
+	Filter      *Filter  `json:"filter,omitempty"`
 }
 
 // CreateWebhookWithContext creates a new webhook.


### PR DESCRIPTION
having non-pointer non-omitempty fields meant we were sending invalid params for updates, this means we only send the fields we set.